### PR TITLE
adapt process to provided access token

### DIFF
--- a/src/Majora/Bundle/OAuthServerBundle/Resources/config/mapping/ORM/Token.orm.yml
+++ b/src/Majora/Bundle/OAuthServerBundle/Resources/config/mapping/ORM/Token.orm.yml
@@ -14,8 +14,7 @@ Majora\Component\OAuth\Entity\Token:
             generator: { strategy: AUTO }
     fields:
         hash:
-            type: string
-            length: 128
+            type: text
         expireIn:
             type: integer
         expireAt:

--- a/src/Majora/Bundle/OAuthServerBundle/Security/AccessTokenAuthenticator.php
+++ b/src/Majora/Bundle/OAuthServerBundle/Security/AccessTokenAuthenticator.php
@@ -53,7 +53,8 @@ class AccessTokenAuthenticator extends AbstractGuardAuthenticator
 
             // token through headers
             case $request->headers->has('Authorization') :
-                if (!preg_match('#^Bearer ([\w]+)$#', $request->headers->get('Authorization'), $matches)) {
+                $accessTokenPattern = '[\w--_]+';
+                if (!preg_match(sprintf('#^Bearer (%s)$#', $accessTokenPattern), $request->headers->get('Authorization'), $matches)) {
                     break; // bad Authorization format
                 }
 


### PR DESCRIPTION
Pass Axa's token provider returns big access token like : 
`eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dSI6Imh0dHBzOi8vbWFhbS1kZXYuYXBwbGljYXRpb25zLnNlcnZpY2VzLmF4YS10ZWNoLmludHJheGE6NDQzL3g1dV9hdC8yMzRGRjhFMzM4Mzc2NTBFREJFMUE3QTNFMENFQkYwQ0MxMDA1QkU4Iiwia2lkIjoiMjM0RkY4RTMzODM3NjUwRURCRTFBN0EzRTBDRUJGMENDMTAwNUJFOCJ9.ew0KCSJzdWIiOiB7InZhbHVlIjogIkdJUi5UZXN0VXNlckBheGEtYmFucXVlLmZyIn0sDQoJImF1ZCI6ICJiYjMwODg3OS1iMWRkLTQ2N2UtYWRmOC03OWNhN2ZkYzBjMTEiLA0KCSJleHAiOiAiMTQ1NzczNzY0NSIsDQoJImFtciI6ICIiLA0KCSJzY29wZSI6ICJEU0lfQVhBQmFucXVlX0lUYWdZb3UiLA0KCSJub25jZSI6ICI1M2EwMmY0Ny1kY2FjLTRkZjMtYmZkYS1mNzViZWRiNWE0YTciDQp9.B4LnwquJyMy9TnfJymM5uQkvbwQ-k1cH5BzC5Nvgw-zI02Ae3zOGCRyAKAgENAFdDn3xULLJKbZniITnoKpbbZjOR1cA320PkfUzv5tL0JC5nC06JZU22ginBWK_0o9Kpdk8M-jeF0-PxfSviygl8pJKRcsQ8Zd_PFqybySn_ypAFRqQQVC65rb1WioABqMMLcGyUlYP3Qn0UEE-dUnq3hocGr5QOmNpiyB6I3npX8pUlDGEOIDRNYfUa3d-aAQNHFExJH833PtrAstibC9VEqJatWl7VMxtbRTSFHU7g6oGZQKTdckUUSZ5vOIGUJlRar1ToI_DyjiNtkCJbLX68Q`
