### PR TITLE
Added support for client_credentials grant type.

### DIFF
--- a/src/Majora/Bundle/OAuthServerBundle/Resources/config/services/extensions.xml
+++ b/src/Majora/Bundle/OAuthServerBundle/Resources/config/services/extensions.xml
@@ -22,6 +22,12 @@
             <argument type="service" id="majora.oauth.refresh_token.loader" />
         </service>
 
-    </services>
+        <!-- Client credentials grant extension -->
+        <service id="majora.oauth.grant_extension.client_credentials" public="false"
+                 class="Majora\Component\OAuth\GrantType\ClientCredentialsGrantExtension"
+        >
+        </service>
+
+</services>
 
 </container>

--- a/src/Majora/Bundle/OAuthServerBundle/Resources/config/services/server.xml
+++ b/src/Majora/Bundle/OAuthServerBundle/Resources/config/services/server.xml
@@ -23,6 +23,7 @@
             <argument type="collection">
                 <argument key="password" type="service" id="majora.oauth.grant_extension.password" />
                 <argument key="refresh_token" type="service" id="majora.oauth.grant_extension.refresh_token" />
+                <argument key="client_credentials" type="service" id="majora.oauth.grant_extension.client_credentials" />
             </argument>
         </service>
         <service id="oauth.server" alias="majora.oauth.server" />

--- a/src/Majora/Component/OAuth/Entity/AccessToken.php
+++ b/src/Majora/Component/OAuth/Entity/AccessToken.php
@@ -51,7 +51,7 @@ class AccessToken extends Token implements AccessTokenInterface, CollectionableI
     public static function getScopes()
     {
         return array(
-            'default' => array('id', 'hash', 'expire_in', 'refresh_token', 'application@id', 'account@id'),
+            'default' => array('id', 'hash', 'expire_in', 'refresh_token', 'application@id', 'account@id?'),
         );
     }
 }

--- a/src/Majora/Component/OAuth/GrantType/ClientCredentialsGrantExtension.php
+++ b/src/Majora/Component/OAuth/GrantType/ClientCredentialsGrantExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Majora\Component\OAuth\GrantType;
+
+use Majora\Component\OAuth\Entity\LoginAttempt;
+use Majora\Component\OAuth\Model\ApplicationInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Built-in extension for client credentials granting.
+ */
+class ClientCredentialsGrantExtension implements GrantExtensionInterface
+{
+    /**
+     * @see GrantExtensionInterface::configureRequestParameters()
+     */
+    public function configureRequestParameters(OptionsResolver $requestResolver)
+    {
+        // No need to require additional request parameters.
+    }
+
+    /**
+     * @see GrantExtensionInterface::grant()
+     */
+    public function grant(ApplicationInterface $application, LoginAttempt $loginAttempt)
+    {
+        // No need to load an Account for this type of grant, the Application alone is enough.
+        return null;
+    }
+}

--- a/src/Majora/Component/OAuth/GrantType/GrantExtensionInterface.php
+++ b/src/Majora/Component/OAuth/GrantType/GrantExtensionInterface.php
@@ -24,7 +24,7 @@ interface GrantExtensionInterface
      * @param ApplicationInterface $application
      * @param LoginAttempt         $loginAttempt
      *
-     * @return AccountInterface
+     * @return AccountInterface|null
      *
      * @throws InvalidGrantException
      */


### PR DESCRIPTION
This PR only includes the bare minimum for supporting the client_credentials grant type.

For now:
- There are no unit tests on the new ClientCredentialsGrantExtension;
- The Application::$allowedGrantTypes attribute is still not used, mainly because checking the compatibility between this attribute and the submitted grant type requires a refactoring of the Server unit tests (and might result into conflicts with the other pending PRs).

Unfortunately, I will not be able to contribute more on this feature, due to time constraints.
However, I am interested in feedbacks on these changes.
